### PR TITLE
Fixed some attribute errors and missing comma in FL packet

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -871,7 +871,7 @@ class ClientManager:
 					self.mod_profile_name = matches[0]
 					with open(modfile, 'r') as chars:
 						mods = yaml.safe_load(chars)
-					mods.append({'name': matches[0], 'status': 'mod', 'ipid': c.ipid})
+					mods.append({'name': matches[0], 'status': 'mod', 'ipid': self.ipid})
 					with open(modfile, 'w', encoding='utf-8') as dump:
 						yaml.dump(mods, dump)
 					return self.mod_profile_name

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -80,7 +80,7 @@ def ooc_cmd_spy(client, arg):
 			raise ArgumentError('Area not recognized.')
 		spyhere.spies.add(client)
 		client.spying.append(spyhere)
-		return send_ooc(f'You are now spying in {spyhere.name}.')
+		return client.send_ooc(f'You are now spying in {spyhere.name}.')
 
 def ooc_cmd_allowmusic(client, arg):
 	if client not in client.area.owners and not client.is_mod:

--- a/server/commands/music.py
+++ b/server/commands/music.py
@@ -63,7 +63,7 @@ def ooc_cmd_addmusic(client, arg):
 		try:
 			length = int(args[1])
 		except ValueError:
-			raise ClientError(f'{length} does not look like a valid length.')
+			raise ClientError(f'Given length does not look like a valid length.')
 		if len(mlist) == 0:
 			songs = []
 			mlist.append({'category': 'CUSTOM'})
@@ -203,7 +203,7 @@ def ooc_cmd_hubplay(client, arg):
 	elif len(arg) > 0:
 		custom = False
 		try:
-			name, length, mod, custom = self.server.get_song_data(arg, self.client.area)
+			name, length, mod, custom = client.server.get_song_data(arg, client.client.area)
 		except:
 			name = arg
 			length = -1

--- a/server/commands/roleplay.py
+++ b/server/commands/roleplay.py
@@ -72,7 +72,7 @@ def ooc_cmd_addrole(client, arg):
 		try:
 			id = int(arg[0])
 		except:
-			raise ArgumentError(f'{id} does not look like a valid ID.')
+			raise ArgumentError('Given ID does not look like a valid ID.')
 	if len(arg) < 2:
 		raise ArgumentError('Not enough arguments! Use /addrole [id] [role].')
 	party = client.party
@@ -408,7 +408,7 @@ def ooc_cmd_destroyparty(client, arg):
 		try:
 			id = int(arg)
 		except:
-			raise ArgumentError(f'{id} does not look like a valid ID.')
+			raise ArgumentError('Given ID does not look like a valid ID.')
 		for party in client.server.parties:
 			parties = []
 			parties.add(party)
@@ -437,7 +437,7 @@ def ooc_cmd_joinparty(client, arg):
 		try:
 			id = int(arg)
 		except:
-			raise ArgumentError(f'{id} does not look like a valid ID.')
+			raise ArgumentError('Given ID does not look like a valid ID.')
 		for party in client.server.parties:
 			if id == party.id:
 				if party.lock:
@@ -492,7 +492,7 @@ def ooc_cmd_partykick(client, arg):
 		try:
 			id = int(arg)
 		except:
-			raise ArgumentError(f'{id} does not look like a valid ID.')
+			raise ArgumentError('Given ID does not look like a valid ID.')
 	party = client.party
 	users = set()
 	for member in party.users:

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -235,8 +235,13 @@ class AOProtocol(asyncio.Protocol):
 		
 		ID#<pv:int>#<software:string>#<version:string>#%
 		"""
-		self.client.send_command('FL', 'yellowtext', 'customobjections', 'flipping', 'fastloading', 'noencryption',
-								 'deskmod', 'evidence', 'modcall_reason', 'cccc_ic_support', 'arup', 'casing_alerts', 'looping_sfx', 'additive', 'effects', 'prezoom' 'y_offset', 'expanded_desk_mods')
+		self.client.send_command('FL', 'yellowtext', 'customobjections', 
+								 'flipping', 'fastloading', 'noencryption',
+								 'deskmod', 'evidence', 
+								 'modcall_reason', 'cccc_ic_support', 
+								 'arup', 'casing_alerts', 
+								 'looping_sfx', 'additive', 'effects', 
+								 'prezoom', 'y_offset', 'expanded_desk_mods')
 
 		# Send Asset packet if asset_url is defined
 		if self.server.config['asset_url'] != '':


### PR DESCRIPTION
During the time I've used TsuserverCC in my own server, I've come across multiple little attribute errors that could hinder a command from working properly or finish running. In this pull request I fixed some or replaced the undefined variables with simple workarounds. 

Additionally, I added a missing comma in the FL Packet which hindered the server from having a working vertical offset on WebAO. I broke up the FL Packet in several lines as well so it's easier to read. 